### PR TITLE
fixed scrolling on patient show list. Titles stay at top while list moves.

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -254,10 +254,12 @@ button:hover {
 
 .compVacc {
     grid-area: C;
+    justify-items: center;
+    text-align: center;
     background-color: rgb(245, 174, 174);
     border-radius: 20px;
     text-align: center;
-    overflow: auto;
+    overflow: hidden;
 
 }
 
@@ -267,8 +269,12 @@ button:hover {
     text-align: center;
     background-color: rgb(112, 219, 238);
     border-radius: 20px;
-    overflow: auto;
+    overflow: hidden;
 } 
+
+.vaccList {
+    overflow: auto;
+}
 
 
 /* EDIT PAGE */
@@ -598,7 +604,7 @@ input {
     text-align: center;
     background-color: #f5aeae;
     border-radius: 20px;
-    overflow: scroll;
+    overflow: hidden;
 
 }
 
@@ -606,11 +612,15 @@ input {
     grid-area: I;
     margin: 0;
     text-align: center;
-    background-color: rgb(112, 219, 238);
+    background-color: rgb(130, 217, 233);
     border-radius: 20px;
-    overflow: scroll;
+    overflow: hidden;
 } 
 
+
+.vaccList {
+    overflow: auto;
+}
 .patientProfile {
     max-width:20%;
     height:auto;


### PR DESCRIPTION
fixed issue where titles stay static on both vaccine lists while the vaccines scroll. Fixed this on desktop and mobile